### PR TITLE
Exact sized con iter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,9 +225,8 @@ dependencies = [
 
 [[package]]
 name = "orx-concurrent-queue"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2b4b34509848c6089f1759829b5e910529ce2b081f7f4f6c79b4e7c7398567"
+version = "1.2.0"
+source = "git+https://github.com/orxfun/orx-concurrent-queue?branch=expose-num-popped#c4f150ab78fada8ae15b78652608066f2f49c839"
 dependencies = [
  "orx-fixed-vec",
  "orx-pinned-vec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "orx-concurrent-recursive-iter"
-version = "2.0.0"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "orx-concurrent-bag",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "orx-concurrent-recursive-iter"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "criterion",
  "orx-concurrent-bag",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "ciborium"
@@ -70,18 +70,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "criterion"
@@ -138,24 +138,25 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasip2",
 ]
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -175,9 +176,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "memchr"
@@ -216,6 +217,14 @@ dependencies = [
 [[package]]
 name = "orx-concurrent-iter"
 version = "3.2.0"
+dependencies = [
+ "orx-iterable",
+ "orx-pseudo-default",
+]
+
+[[package]]
+name = "orx-concurrent-iter"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2bc35dba600d3a9d975c7932933e355ddf37815dd2efa228c7ae57abc911c60"
 dependencies = [
@@ -226,7 +235,6 @@ dependencies = [
 [[package]]
 name = "orx-concurrent-queue"
 version = "1.2.0"
-source = "git+https://github.com/orxfun/orx-concurrent-queue?branch=expose-num-popped#c4f150ab78fada8ae15b78652608066f2f49c839"
 dependencies = [
  "orx-fixed-vec",
  "orx-pinned-vec",
@@ -239,7 +247,7 @@ version = "1.1.0"
 dependencies = [
  "criterion",
  "orx-concurrent-bag",
- "orx-concurrent-iter",
+ "orx-concurrent-iter 3.2.0",
  "orx-concurrent-queue",
  "orx-fixed-vec",
  "orx-pinned-vec",
@@ -255,7 +263,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "039e7861dcde4a2722c0054e809f7027172078e3ed6496df6bf4ea6d8f499089"
 dependencies = [
- "orx-concurrent-iter",
+ "orx-concurrent-iter 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "orx-iterable",
  "orx-pinned-vec",
  "orx-pseudo-default",
@@ -310,7 +318,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09515b6021666927ecef8b567de04c5d26dcb3c5ff5b70ed4089e5618a7ee814"
 dependencies = [
- "orx-concurrent-iter",
+ "orx-concurrent-iter 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "orx-iterable",
  "orx-pinned-vec",
  "orx-pseudo-default",
@@ -380,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -392,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -403,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "ryu"
@@ -467,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -533,15 +541,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,18 +70,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.49"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
+checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.49"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
+checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -216,17 +216,9 @@ dependencies = [
 
 [[package]]
 name = "orx-concurrent-iter"
-version = "3.2.0"
-dependencies = [
- "orx-iterable",
- "orx-pseudo-default",
-]
-
-[[package]]
-name = "orx-concurrent-iter"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2bc35dba600d3a9d975c7932933e355ddf37815dd2efa228c7ae57abc911c60"
+checksum = "78e4381d6f1393a99e5a2bebe63e7a4c58c2526cdf25e01830baa11410c7ece1"
 dependencies = [
  "orx-iterable",
  "orx-pseudo-default",
@@ -247,7 +239,7 @@ version = "1.1.0"
 dependencies = [
  "criterion",
  "orx-concurrent-bag",
- "orx-concurrent-iter 3.2.0",
+ "orx-concurrent-iter",
  "orx-concurrent-queue",
  "orx-fixed-vec",
  "orx-pinned-vec",
@@ -259,11 +251,11 @@ dependencies = [
 
 [[package]]
 name = "orx-fixed-vec"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039e7861dcde4a2722c0054e809f7027172078e3ed6496df6bf4ea6d8f499089"
+checksum = "96586d7477170175263986dfdfd36cc9a4b08bcc1743084f06115d6610181bb4"
 dependencies = [
- "orx-concurrent-iter 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "orx-concurrent-iter",
  "orx-iterable",
  "orx-pinned-vec",
  "orx-pseudo-default",
@@ -292,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "orx-pinned-vec"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b8a3e9913e68446bcf7e1d6faaecd6192a8009ae13bce83d43073d989308c0"
+checksum = "d38ff024d902a587fefdc502598107bbbf3d2a5350d63247bef34bd6a5518de9"
 dependencies = [
  "orx-iterable",
  "orx-pseudo-default",
@@ -314,11 +306,11 @@ checksum = "67a8e35dfe18921e475b9861266fd58a5ecfd681161f242d24a9e2d1e07fbc28"
 
 [[package]]
 name = "orx-split-vec"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09515b6021666927ecef8b567de04c5d26dcb3c5ff5b70ed4089e5618a7ee814"
+checksum = "794100ff181e3903c90398e91147bbba7734ab0a1c6e13c4c569f4a15bccd6f7"
 dependencies = [
- "orx-concurrent-iter 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "orx-concurrent-iter",
  "orx-iterable",
  "orx-pinned-vec",
  "orx-pseudo-default",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ orx-concurrent-iter = { version = "3.2.0", default-features = false }
 orx-pinned-vec = { version = "3.20.0", default-features = false }
 orx-split-vec = { version = "3.21.0", default-features = false }
 orx-fixed-vec = { version = "3.21.0", default-features = false }
-orx-concurrent-queue = { version = "1.1.0", default-features = false }
+# orx-concurrent-queue = { version = "1.1.0", default-features = false }
+orx-concurrent-queue = { git = "https://github.com/orxfun/orx-concurrent-queue", branch = "expose-num-popped" }
 
 [dev-dependencies]
 criterion = { version = "0.7.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-recursive-iter"
-version = "2.0.0"
+version = "1.1.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A concurrent iterator that can be extended recursively by each of its items."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-recursive-iter"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A concurrent iterator that can be extended recursively by each of its items."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,14 @@ keywords = ["concurrency", "iterator", "iteration", "recursive", "parallelism"]
 categories = ["data-structures", "concurrency", "rust-patterns", "no-std"]
 
 [dependencies]
-orx-concurrent-iter = { version = "3.2.0", default-features = false }
+# orx-concurrent-iter = { version = "3.2.0", default-features = false }
+orx-concurrent-iter = { path = "../orx-concurrent-iter", default-features = false }
 orx-pinned-vec = { version = "3.20.0", default-features = false }
 orx-split-vec = { version = "3.21.0", default-features = false }
 orx-fixed-vec = { version = "3.21.0", default-features = false }
 # orx-concurrent-queue = { version = "1.1.0", default-features = false }
-orx-concurrent-queue = { git = "https://github.com/orxfun/orx-concurrent-queue", branch = "expose-num-popped" }
+# orx-concurrent-queue = { git = "https://github.com/orxfun/orx-concurrent-queue", branch = "expose-num-popped" }
+orx-concurrent-queue = { path = "../orx-concurrent-queue" }
 
 [dev-dependencies]
 criterion = { version = "0.7.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-recursive-iter"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A concurrent iterator that can be extended recursively by each of its items."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-recursive-iter"
-version = "1.1.0"
+version = "1.0.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A concurrent iterator that can be extended recursively by each of its items."
@@ -10,18 +10,15 @@ keywords = ["concurrency", "iterator", "iteration", "recursive", "parallelism"]
 categories = ["data-structures", "concurrency", "rust-patterns", "no-std"]
 
 [dependencies]
-# orx-concurrent-iter = { version = "3.2.0", default-features = false }
-orx-concurrent-iter = { path = "../orx-concurrent-iter", default-features = false }
-orx-pinned-vec = { version = "3.20.0", default-features = false }
-orx-split-vec = { version = "3.21.0", default-features = false }
-orx-fixed-vec = { version = "3.21.0", default-features = false }
-# orx-concurrent-queue = { version = "1.1.0", default-features = false }
-# orx-concurrent-queue = { git = "https://github.com/orxfun/orx-concurrent-queue", branch = "expose-num-popped" }
-orx-concurrent-queue = { path = "../orx-concurrent-queue" }
+orx-concurrent-iter = { version = "3.3.0", default-features = false }
+orx-pinned-vec = { version = "3.21.0", default-features = false }
+orx-split-vec = { version = "3.22.0", default-features = false }
+orx-fixed-vec = { version = "3.22.0", default-features = false }
+orx-concurrent-queue = { version = "1.2.0", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.7.0", default-features = false }
-orx-concurrent-bag = { version = "3.1.0" }
+orx-concurrent-bag = { version = "3.4.0" }
 rand_chacha = { version = "0.9.0" }
 rand = { version = "0.9.2" }
 test-case = { version = "3.3.1" }

--- a/src/con_iter.rs
+++ b/src/con_iter.rs
@@ -308,9 +308,20 @@ where
     /// let initial_elements = [1];
     ///
     /// let iter = ConcurrentRecursiveIter::new_exact(extend, initial_elements, 5);
-    /// let all: Vec<_> = iter.item_puller().collect();
+    /// assert_eq!(iter.len(), 5);
     ///
-    /// assert_eq!(all, [1, 2, 3, 4, 5]);
+    /// assert_eq!(iter.next(), Some(1));
+    /// assert_eq!(iter.len(), 4);
+    ///
+    /// assert_eq!(iter.next(), Some(2));
+    /// assert_eq!(iter.len(), 3);
+    ///
+    /// let remaining: Vec<_> = iter.item_puller().collect();
+    /// assert_eq!(remaining, [3, 4, 5]);
+    /// assert_eq!(iter.len(), 0);
+    ///
+    /// assert_eq!(iter.next(), None);
+    /// assert_eq!(iter.len(), 0);
     /// ```
     ///
     /// # Examples - From
@@ -440,39 +451,4 @@ where
     fn len(&self) -> usize {
         self.exact_len - self.queue.num_popped(Ordering::Relaxed)
     }
-}
-
-#[test]
-fn abc() {
-    use alloc::vec::Vec;
-
-    let initial_elements = [1];
-
-    // SplitVec with Linear growth
-    let queue = ConcurrentQueue::with_linear_growth(10, 4);
-    queue.extend(initial_elements);
-    let extend = |x: &usize| (*x < 5).then_some(x + 1);
-    let iter = ConcurrentRecursiveIter::from((extend, queue));
-
-    let all: Vec<_> = iter.item_puller().collect();
-    assert_eq!(all, [1, 2, 3, 4, 5]);
-
-    // FixedVec with fixed capacity
-    let queue = ConcurrentQueue::with_fixed_capacity(5);
-    queue.extend(initial_elements);
-    let extend = |x: &usize| (*x < 5).then_some(x + 1);
-    let iter = ConcurrentRecursiveIter::from((extend, queue));
-
-    let all: Vec<_> = iter.item_puller().collect();
-    assert_eq!(all, [1, 2, 3, 4, 5]);
-
-    //
-
-    let extend = |x: &usize| (*x < 5).then_some(x + 1);
-    let initial_elements = [1];
-
-    let iter = ConcurrentRecursiveIter::new_exact(extend, initial_elements, 5);
-    let all: Vec<_> = iter.item_puller().collect();
-
-    assert_eq!(all, [1, 2, 3, 4, 5]);
 }

--- a/src/con_iter.rs
+++ b/src/con_iter.rs
@@ -2,7 +2,7 @@ use crate::{
     ExactSize, Size, UnknownSize, chunk_puller::DynChunkPuller, dyn_seq_queue::DynSeqQueue,
 };
 use core::{marker::PhantomData, sync::atomic::Ordering};
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::{ConcurrentIter, ExactSizeConcurrentIter};
 use orx_concurrent_queue::{ConcurrentQueue, DefaultConPinnedVec};
 use orx_pinned_vec::{ConcurrentPinnedVec, IntoConcurrentPinnedVec};
 use orx_split_vec::SplitVec;
@@ -151,9 +151,21 @@ where
     /// collection under the hood. In order to crate the iterator using a different queue
     /// use the `From`/`Into` traits, as demonstrated below.
     ///
+    /// # UnknownSize vs ExactSize
+    ///
     /// Note that the iterator created with this method will have [`UnknownSize`].
     /// In order to create a recursive iterator with a known exact length, you may use
     /// `ConcurrentRecursiveIter::new(extend, initial_elements, exact_len)` function.
+    ///
+    /// Providing an `exact_len` impacts the following:
+    /// * When an exact length is provided, the recursive iterator implements
+    ///   [`ExactSizeConcurrentIter`] in addition to [`ConcurrentIter`].
+    ///   This enables the `len` method to access the number of remaining elements in a
+    ///   concurrent program. When this is not necessary, the exact length argument
+    ///   can simply be skipped.
+    /// * On the other hand, a known length is very useful for performance optimization
+    ///   when the recursive iterator is used as the input of a parallel iterator of the
+    ///   [orx_parallel](https://crates.io/crates/orx-parallel) crate.
     ///
     /// # Examples
     ///

--- a/src/con_iter.rs
+++ b/src/con_iter.rs
@@ -108,7 +108,7 @@ where
 {
     queue: ConcurrentQueue<T, P>,
     extend: E,
-    exact_len: usize,
+    exact_len: S::ExactLen,
     p: PhantomData<S>,
 }
 
@@ -128,7 +128,7 @@ where
         Self {
             queue,
             extend,
-            exact_len: usize::MAX,
+            exact_len: (),
             p: PhantomData,
         }
     }

--- a/src/con_iter.rs
+++ b/src/con_iter.rs
@@ -7,6 +7,18 @@ use orx_concurrent_queue::{ConcurrentQueue, DefaultConPinnedVec};
 use orx_pinned_vec::{ConcurrentPinnedVec, IntoConcurrentPinnedVec};
 use orx_split_vec::SplitVec;
 
+// type aliases for exact an unknown
+
+/// A [`ConcurrentRecursiveIterCore`] with [`UnknownSize`].
+pub type ConcurrentRecursiveIter<T, E, I, P = DefaultConPinnedVec<T>> =
+    ConcurrentRecursiveIterCore<UnknownSize, T, E, I, P>;
+
+/// A [`ConcurrentRecursiveIterCore`] with [`ExactSize`].
+pub type ConcurrentRecursiveIterExact<T, E, I, P = DefaultConPinnedVec<T>> =
+    ConcurrentRecursiveIterCore<ExactSize, T, E, I, P>;
+
+// core
+
 /// A recursive [`ConcurrentIter`] which:
 /// * naturally shrinks as we iterate,
 /// * but can also grow as it allows to add new items to the iterator, during iteration.
@@ -96,7 +108,7 @@ use orx_split_vec::SplitVec;
 ///
 /// assert_eq!(num_processed_nodes.into_inner(), 177);
 /// ```
-pub struct ConcurrentRecursiveIter<S, T, E, I, P = DefaultConPinnedVec<T>>
+pub struct ConcurrentRecursiveIterCore<S, T, E, I, P = DefaultConPinnedVec<T>>
 where
     S: Size,
     T: Send,
@@ -115,7 +127,7 @@ where
 // new with unknown size
 
 impl<T, E, I, P> From<(E, ConcurrentQueue<T, P>)>
-    for ConcurrentRecursiveIter<UnknownSize, T, E, I, P>
+    for ConcurrentRecursiveIterCore<UnknownSize, T, E, I, P>
 where
     T: Send,
     E: Fn(&T) -> I + Sync,
@@ -134,7 +146,7 @@ where
     }
 }
 
-impl<T, E, I> ConcurrentRecursiveIter<UnknownSize, T, E, I, DefaultConPinnedVec<T>>
+impl<T, E, I> ConcurrentRecursiveIterCore<UnknownSize, T, E, I, DefaultConPinnedVec<T>>
 where
     T: Send,
     E: Fn(&T) -> I + Sync,
@@ -239,7 +251,7 @@ where
 // new with exact size
 
 impl<T, E, I, P> From<(E, ConcurrentQueue<T, P>, usize)>
-    for ConcurrentRecursiveIter<ExactSize, T, E, I, P>
+    for ConcurrentRecursiveIterCore<ExactSize, T, E, I, P>
 where
     T: Send,
     E: Fn(&T) -> I + Sync,
@@ -258,7 +270,7 @@ where
     }
 }
 
-impl<T, E, I> ConcurrentRecursiveIter<ExactSize, T, E, I, DefaultConPinnedVec<T>>
+impl<T, E, I> ConcurrentRecursiveIterCore<ExactSize, T, E, I, DefaultConPinnedVec<T>>
 where
     T: Send,
     E: Fn(&T) -> I + Sync,
@@ -381,7 +393,7 @@ where
 
 // con iter
 
-impl<S, T, E, I, P> ConcurrentIter for ConcurrentRecursiveIter<S, T, E, I, P>
+impl<S, T, E, I, P> ConcurrentIter for ConcurrentRecursiveIterCore<S, T, E, I, P>
 where
     S: Size,
     T: Send,
@@ -439,7 +451,7 @@ where
     }
 }
 
-impl<T, E, I, P> ExactSizeConcurrentIter for ConcurrentRecursiveIter<ExactSize, T, E, I, P>
+impl<T, E, I, P> ExactSizeConcurrentIter for ConcurrentRecursiveIterCore<ExactSize, T, E, I, P>
 where
     T: Send,
     E: Fn(&T) -> I + Sync,

--- a/src/con_iter.rs
+++ b/src/con_iter.rs
@@ -439,7 +439,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        match self.exact_len.len() {
+        match self.exact_len.exact_len() {
             Some(exact_len) => {
                 let popped = self.queue.num_popped(Ordering::Relaxed);
                 let remaining = exact_len - popped;

--- a/src/con_iter.rs
+++ b/src/con_iter.rs
@@ -151,6 +151,10 @@ where
     /// collection under the hood. In order to crate the iterator using a different queue
     /// use the `From`/`Into` traits, as demonstrated below.
     ///
+    /// Note that the iterator created with this method will have [`UnknownSize`].
+    /// In order to create a recursive iterator with a known exact length, you may use
+    /// `ConcurrentRecursiveIter::new(extend, initial_elements, exact_len)` function.
+    ///
     /// # Examples
     ///
     /// The following is a simple example to demonstrate how the dynamic iterator works.

--- a/src/con_iter.rs
+++ b/src/con_iter.rs
@@ -438,7 +438,7 @@ where
     <P as ConcurrentPinnedVec<T>>::P: IntoConcurrentPinnedVec<T, ConPinnedVec = P>,
 {
     fn len(&self) -> usize {
-        todo!()
+        self.exact_len - self.queue.num_popped(Ordering::Relaxed)
     }
 }
 

--- a/src/con_iter.rs
+++ b/src/con_iter.rs
@@ -1,7 +1,7 @@
 use crate::{
     ExactSize, Size, UnknownSize, chunk_puller::DynChunkPuller, dyn_seq_queue::DynSeqQueue,
 };
-use core::{marker::PhantomData, sync::atomic::Ordering, usize};
+use core::{marker::PhantomData, sync::atomic::Ordering};
 use orx_concurrent_iter::{ConcurrentIter, ExactSizeConcurrentIter};
 use orx_concurrent_queue::{ConcurrentQueue, DefaultConPinnedVec};
 use orx_pinned_vec::{ConcurrentPinnedVec, IntoConcurrentPinnedVec};

--- a/src/con_iter.rs
+++ b/src/con_iter.rs
@@ -183,7 +183,7 @@ where
     ///   when the recursive iterator is used as the input of a parallel iterator of the
     ///   [orx_parallel](https://crates.io/crates/orx-parallel) crate.
     ///
-    /// [`new_exact`]: ConcurrentRecursiveIter::new_exact
+    /// [`new_exact`]: ConcurrentRecursiveIterExact::new_exact
     ///
     /// # Examples
     ///
@@ -319,7 +319,7 @@ where
     /// let extend = |x: &usize| (*x < 5).then_some(x + 1);
     /// let initial_elements = [1];
     ///
-    /// let iter = ConcurrentRecursiveIter::new_exact(extend, initial_elements, 5);
+    /// let iter = ConcurrentRecursiveIterExact::new_exact(extend, initial_elements, 5);
     /// assert_eq!(iter.len(), 5);
     ///
     /// assert_eq!(iter.next(), Some(1));
@@ -360,7 +360,7 @@ where
     /// let queue = ConcurrentQueue::with_linear_growth(10, 4);
     /// queue.extend(initial_elements);
     /// let extend = |x: &usize| (*x < 5).then_some(x + 1);
-    /// let iter = ConcurrentRecursiveIter::from((extend, queue, 5));
+    /// let iter = ConcurrentRecursiveIterExact::from((extend, queue, 5));
     ///
     /// let all: Vec<_> = iter.item_puller().collect();
     /// assert_eq!(all, [1, 2, 3, 4, 5]);
@@ -369,7 +369,7 @@ where
     /// let queue = ConcurrentQueue::with_fixed_capacity(5);
     /// queue.extend(initial_elements);
     /// let extend = |x: &usize| (*x < 5).then_some(x + 1);
-    /// let iter = ConcurrentRecursiveIter::from((extend, queue, 5));
+    /// let iter = ConcurrentRecursiveIterExact::from((extend, queue, 5));
     ///
     /// let all: Vec<_> = iter.item_puller().collect();
     /// assert_eq!(all, [1, 2, 3, 4, 5]);

--- a/src/con_iter.rs
+++ b/src/con_iter.rs
@@ -120,7 +120,7 @@ where
 {
     queue: ConcurrentQueue<T, P>,
     extend: E,
-    exact_len: S::ExactLen,
+    exact_len: S,
     p: PhantomData<S>,
 }
 
@@ -140,7 +140,7 @@ where
         Self {
             queue,
             extend,
-            exact_len: (),
+            exact_len: UnknownSize,
             p: PhantomData,
         }
     }
@@ -264,7 +264,7 @@ where
         Self {
             queue,
             extend,
-            exact_len,
+            exact_len: ExactSize(exact_len),
             p: PhantomData,
         }
     }
@@ -461,6 +461,6 @@ where
     <P as ConcurrentPinnedVec<T>>::P: IntoConcurrentPinnedVec<T, ConPinnedVec = P>,
 {
     fn len(&self) -> usize {
-        self.exact_len - self.queue.num_popped(Ordering::Relaxed)
+        self.exact_len.0 - self.queue.num_popped(Ordering::Relaxed)
     }
 }

--- a/src/con_iter.rs
+++ b/src/con_iter.rs
@@ -439,10 +439,19 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let min = self.queue.len();
-        match min {
-            0 => (0, Some(0)),
-            n => (n, None),
+        match self.exact_len.len() {
+            Some(exact_len) => {
+                let popped = self.queue.num_popped(Ordering::Relaxed);
+                let remaining = exact_len - popped;
+                (remaining, Some(remaining))
+            }
+            None => {
+                let min = self.queue.len();
+                match min {
+                    0 => (0, Some(0)),
+                    n => (n, None),
+                }
+            }
         }
     }
 

--- a/src/con_iter.rs
+++ b/src/con_iter.rs
@@ -195,6 +195,31 @@ where
     /// pre-allocated [`FixedVec`] as the underlying storage. In order to do so, we can
     /// use the `From` trait.
     ///
+    /// ```
+    /// use orx_concurrent_recursive_iter::*;
+    /// use orx_concurrent_queue::ConcurrentQueue;
+    ///
+    /// let initial_elements = [1];
+    ///
+    /// // SplitVec with Linear growth
+    /// let queue = ConcurrentQueue::with_linear_growth(10, 4);
+    /// queue.extend(initial_elements);
+    /// let extend = |x: &usize| (*x < 5).then_some(x + 1);
+    /// let iter = ConcurrentRecursiveIter::from((extend, queue));
+    ///
+    /// let all: Vec<_> = iter.item_puller().collect();
+    /// assert_eq!(all, [1, 2, 3, 4, 5]);
+    ///
+    /// // FixedVec with fixed capacity
+    /// let queue = ConcurrentQueue::with_fixed_capacity(5);
+    /// queue.extend(initial_elements);
+    /// let extend = |x: &usize| (*x < 5).then_some(x + 1);
+    /// let iter = ConcurrentRecursiveIter::from((extend, queue));
+    ///
+    /// let all: Vec<_> = iter.item_puller().collect();
+    /// assert_eq!(all, [1, 2, 3, 4, 5]);
+    /// ```
+    ///
     /// [`SplitVec`]: orx_split_vec::SplitVec
     /// [`FixedVec`]: orx_fixed_vec::FixedVec
     /// [`Doubling`]: orx_split_vec::Doubling
@@ -269,8 +294,7 @@ where
     /// The following is a simple example to demonstrate how the dynamic iterator works.
     ///
     /// ```
-    /// use orx_concurrent_recursive_iter::ConcurrentRecursiveIter;
-    /// use orx_concurrent_iter::ConcurrentIter;
+    /// use orx_concurrent_recursive_iter::*;
     ///
     /// let extend = |x: &usize| (*x < 5).then_some(x + 1);
     /// let initial_elements = [1];
@@ -289,6 +313,31 @@ where
     /// Alternatively, we can use a `SplitVec` with a [`Linear`] growth strategy, or a
     /// pre-allocated [`FixedVec`] as the underlying storage. In order to do so, we can
     /// use the `From` trait.
+    ///
+    /// ```
+    /// use orx_concurrent_recursive_iter::*;
+    /// use orx_concurrent_queue::ConcurrentQueue;
+    ///
+    /// let initial_elements = [1];
+    ///
+    /// // SplitVec with Linear growth
+    /// let queue = ConcurrentQueue::with_linear_growth(10, 4);
+    /// queue.extend(initial_elements);
+    /// let extend = |x: &usize| (*x < 5).then_some(x + 1);
+    /// let iter = ConcurrentRecursiveIter::from((extend, queue));
+    ///
+    /// let all: Vec<_> = iter.item_puller().collect();
+    /// assert_eq!(all, [1, 2, 3, 4, 5]);
+    ///
+    /// // FixedVec with fixed capacity
+    /// let queue = ConcurrentQueue::with_fixed_capacity(5);
+    /// queue.extend(initial_elements);
+    /// let extend = |x: &usize| (*x < 5).then_some(x + 1);
+    /// let iter = ConcurrentRecursiveIter::from((extend, queue));
+    ///
+    /// let all: Vec<_> = iter.item_puller().collect();
+    /// assert_eq!(all, [1, 2, 3, 4, 5]);
+    /// ```
     ///
     /// [`SplitVec`]: orx_split_vec::SplitVec
     /// [`FixedVec`]: orx_fixed_vec::FixedVec
@@ -364,4 +413,29 @@ where
     fn chunk_puller(&self, chunk_size: usize) -> Self::ChunkPuller<'_> {
         DynChunkPuller::new(&self.extend, &self.queue, chunk_size)
     }
+}
+
+#[test]
+fn abc() {
+    use alloc::vec::Vec;
+
+    let initial_elements = [1];
+
+    // SplitVec with Linear growth
+    let queue = ConcurrentQueue::with_linear_growth(10, 4);
+    queue.extend(initial_elements);
+    let extend = |x: &usize| (*x < 5).then_some(x + 1);
+    let iter = ConcurrentRecursiveIter::from((extend, queue));
+
+    let all: Vec<_> = iter.item_puller().collect();
+    assert_eq!(all, [1, 2, 3, 4, 5]);
+
+    // FixedVec with fixed capacity
+    let queue = ConcurrentQueue::with_fixed_capacity(5);
+    queue.extend(initial_elements);
+    let extend = |x: &usize| (*x < 5).then_some(x + 1);
+    let iter = ConcurrentRecursiveIter::from((extend, queue));
+
+    let all: Vec<_> = iter.item_puller().collect();
+    assert_eq!(all, [1, 2, 3, 4, 5]);
 }

--- a/src/con_iter.rs
+++ b/src/con_iter.rs
@@ -110,6 +110,8 @@ where
     p: PhantomData<S>,
 }
 
+// new with unknown size
+
 impl<T, E, I, P> From<(E, ConcurrentQueue<T, P>)>
     for ConcurrentRecursiveIter<UnknownSize, T, E, I, P>
 where
@@ -197,6 +199,10 @@ where
         (extend, queue).into()
     }
 }
+
+// new with exact size
+
+// con iter
 
 impl<S, T, E, I, P> ConcurrentIter for ConcurrentRecursiveIter<S, T, E, I, P>
 where

--- a/src/con_iter.rs
+++ b/src/con_iter.rs
@@ -455,6 +455,13 @@ where
         }
     }
 
+    fn is_completed_when_none_returned(&self) -> bool {
+        let popped = self.queue.num_popped(Ordering::Relaxed);
+        let write_reserved = self.queue.num_write_reserved(Ordering::Relaxed);
+        let written = self.queue.num_written(Ordering::Relaxed);
+        popped >= write_reserved && write_reserved == written
+    }
+
     fn chunk_puller(&self, chunk_size: usize) -> Self::ChunkPuller<'_> {
         DynChunkPuller::new(&self.extend, &self.queue, chunk_size)
     }

--- a/src/con_iter.rs
+++ b/src/con_iter.rs
@@ -458,8 +458,7 @@ where
     fn is_completed_when_none_returned(&self) -> bool {
         let popped = self.queue.num_popped(Ordering::Relaxed);
         let write_reserved = self.queue.num_write_reserved(Ordering::Relaxed);
-        let written = self.queue.num_written(Ordering::Relaxed);
-        popped >= write_reserved && write_reserved == written
+        popped >= write_reserved
     }
 
     fn chunk_puller(&self, chunk_size: usize) -> Self::ChunkPuller<'_> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,9 @@ mod con_iter;
 mod dyn_seq_queue;
 mod sized;
 
-pub use con_iter::ConcurrentRecursiveIter;
+pub use con_iter::{
+    ConcurrentRecursiveIter, ConcurrentRecursiveIterCore, ConcurrentRecursiveIterExact,
+};
 pub use sized::{ExactSize, Size, UnknownSize};
 
 // re-import

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ mod dyn_seq_queue;
 mod sized;
 
 pub use con_iter::ConcurrentRecursiveIter;
-pub use sized::{ExactSized, Size, UnknownSized};
+pub use sized::{ExactSize, Size, UnknownSize};
 
 // re-import
 pub use orx_concurrent_iter::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod chunk;
 mod chunk_puller;
 mod con_iter;
 mod dyn_seq_queue;
+mod sized;
 
 pub use con_iter::ConcurrentRecursiveIter;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod dyn_seq_queue;
 mod sized;
 
 pub use con_iter::ConcurrentRecursiveIter;
+pub use sized::{ExactSized, Size, UnknownSized};
 
 // re-import
 pub use orx_concurrent_iter::*;

--- a/src/sized.rs
+++ b/src/sized.rs
@@ -7,7 +7,7 @@ pub trait Size: Seal + Send + Sync + Clone + Copy {
     /// will generate if completely consumed.
     ///
     /// Returns None if this is not known ahead of time.
-    fn len(self) -> Option<usize>;
+    fn exact_len(self) -> Option<usize>;
 }
 
 /// The iterator has known exact size.
@@ -16,7 +16,7 @@ pub struct ExactSize(pub(super) usize);
 impl Seal for ExactSize {}
 impl Size for ExactSize {
     #[inline(always)]
-    fn len(self) -> Option<usize> {
+    fn exact_len(self) -> Option<usize> {
         Some(self.0)
     }
 }
@@ -27,7 +27,7 @@ pub struct UnknownSize;
 impl Seal for UnknownSize {}
 impl Size for UnknownSize {
     #[inline(always)]
-    fn len(self) -> Option<usize> {
+    fn exact_len(self) -> Option<usize> {
         None
     }
 }

--- a/src/sized.rs
+++ b/src/sized.rs
@@ -2,14 +2,21 @@ trait Seal {}
 
 /// Marker trait determining whether the iterator is exact-sized or not.
 #[allow(private_bounds)]
-pub trait Size: Seal + Send + Sync {}
+pub trait Size: Seal + Send + Sync {
+    /// Type of the exact length.
+    type ExactLen;
+}
 
 /// The iterator has known exact size.
 pub struct ExactSize;
 impl Seal for ExactSize {}
-impl Size for ExactSize {}
+impl Size for ExactSize {
+    type ExactLen = usize;
+}
 
 /// Size of the iterator is unknown ahead of time.
 pub struct UnknownSize;
 impl Seal for UnknownSize {}
-impl Size for UnknownSize {}
+impl Size for UnknownSize {
+    type ExactLen = ();
+}

--- a/src/sized.rs
+++ b/src/sized.rs
@@ -2,14 +2,14 @@ trait Seal {}
 
 /// Marker trait determining whether the iterator is exact-sized or not.
 #[allow(private_bounds)]
-pub trait Size: Seal {}
+pub trait Size: Seal + Send + Sync {}
 
 /// The iterator has known exact size.
-pub struct ExactSized;
-impl Seal for ExactSized {}
-impl Size for ExactSized {}
+pub struct ExactSize;
+impl Seal for ExactSize {}
+impl Size for ExactSize {}
 
 /// Size of the iterator is unknown ahead of time.
-pub struct UnknownSized;
-impl Seal for UnknownSized {}
-impl Size for UnknownSized {}
+pub struct UnknownSize;
+impl Seal for UnknownSize {}
+impl Size for UnknownSize {}

--- a/src/sized.rs
+++ b/src/sized.rs
@@ -2,21 +2,14 @@ trait Seal {}
 
 /// Marker trait determining whether the iterator is exact-sized or not.
 #[allow(private_bounds)]
-pub trait Size: Seal + Send + Sync {
-    /// Type of the exact length.
-    type ExactLen: Send + Sync;
-}
+pub trait Size: Seal + Send + Sync {}
 
 /// The iterator has known exact size.
-pub struct ExactSize;
+pub struct ExactSize(pub(super) usize);
 impl Seal for ExactSize {}
-impl Size for ExactSize {
-    type ExactLen = usize;
-}
+impl Size for ExactSize {}
 
 /// Size of the iterator is unknown ahead of time.
 pub struct UnknownSize;
 impl Seal for UnknownSize {}
-impl Size for UnknownSize {
-    type ExactLen = ();
-}
+impl Size for UnknownSize {}

--- a/src/sized.rs
+++ b/src/sized.rs
@@ -1,11 +1,15 @@
 trait Seal {}
 
+/// Marker trait determining whether the iterator is exact-sized or not.
+#[allow(private_bounds)]
 pub trait Size: Seal {}
 
+/// The iterator has known exact size.
 pub struct ExactSized;
 impl Seal for ExactSized {}
 impl Size for ExactSized {}
 
+/// Size of the iterator is unknown ahead of time.
 pub struct UnknownSized;
 impl Seal for UnknownSized {}
 impl Size for UnknownSized {}

--- a/src/sized.rs
+++ b/src/sized.rs
@@ -4,7 +4,7 @@ trait Seal {}
 #[allow(private_bounds)]
 pub trait Size: Seal + Send + Sync {
     /// Type of the exact length.
-    type ExactLen;
+    type ExactLen: Send + Sync;
 }
 
 /// The iterator has known exact size.

--- a/src/sized.rs
+++ b/src/sized.rs
@@ -2,14 +2,32 @@ trait Seal {}
 
 /// Marker trait determining whether the iterator is exact-sized or not.
 #[allow(private_bounds)]
-pub trait Size: Seal + Send + Sync {}
+pub trait Size: Seal + Send + Sync + Clone + Copy {
+    /// Returns the total number of elements that the recursive iterator
+    /// will generate if completely consumed.
+    ///
+    /// Returns None if this is not known ahead of time.
+    fn len(self) -> Option<usize>;
+}
 
 /// The iterator has known exact size.
+#[derive(Clone, Copy)]
 pub struct ExactSize(pub(super) usize);
 impl Seal for ExactSize {}
-impl Size for ExactSize {}
+impl Size for ExactSize {
+    #[inline(always)]
+    fn len(self) -> Option<usize> {
+        Some(self.0)
+    }
+}
 
 /// Size of the iterator is unknown ahead of time.
+#[derive(Clone, Copy)]
 pub struct UnknownSize;
 impl Seal for UnknownSize {}
-impl Size for UnknownSize {}
+impl Size for UnknownSize {
+    #[inline(always)]
+    fn len(self) -> Option<usize> {
+        None
+    }
+}

--- a/src/sized.rs
+++ b/src/sized.rs
@@ -1,0 +1,11 @@
+trait Seal {}
+
+pub trait Size: Seal {}
+
+pub struct ExactSized;
+impl Seal for ExactSized {}
+impl Size for ExactSized {}
+
+pub struct UnknownSized;
+impl Seal for UnknownSized {}
+impl Size for UnknownSized {}


### PR DESCRIPTION
Two variants are introduced:

* [`ConcurrentRecursiveIter`]. This is equivalent to the prior implementation with unknown size. Size refers to the total number of elements that will be returned by the iterator, which is the total of initial elements and all elements created by the recursive extend calls.
* [`ConcurrentRecursiveIterExact`]: This is the recursive concurrent iterator where the size is known ahead of time before recursively extending for each element. This is critical in achieving performant parallelization when the recursive concurrent iterator is used as an input of a parallel iteration.

Accordingly, `From` queue implementations are updated. In particular additional implementations are provided to allow for creating exact sized iterators from concurrent queues using any kind of pinned vector for storage.

Upgrades PinnedVec for improved safety guarantees: https://github.com/orxfun/orx-pinned-vec/releases/tag/3.21.0

Upgrades ConcurrentIter for fused iterator behavior of the concurrent iter implementation: https://github.com/orxfun/orx-concurrent-iter/releases/tag/3.3.0. With this update `is_completed_when_none_returned` implementation is provided to allow callers make sure that the iterator is completely consumed.

